### PR TITLE
Extract post-exlink into partials

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,7 +13,7 @@
         {{ .Summary }}
     </div>
     <div id="post-exlink">
-        <a href="{{ .Permalink }}"><i class="fas fa-angle-right"></i>&nbsp;READ MORE&nbsp;<i class="fas fa-angle-left"></i></a>
+        {{ partial "post-exlink.html" . }}
     </div>
 </div>
 {{ end }}

--- a/layouts/partials/post-exlink.html
+++ b/layouts/partials/post-exlink.html
@@ -1,0 +1,3 @@
+<span>
+    <a href="{{ .Permalink }}"><i class="fas fa-angle-right"></i>&nbsp;READ MORE&nbsp;<i class="fas fa-angle-left"></i></a>
+</span>


### PR DESCRIPTION
Hi!

I was looking to customise the `>READ MORE<` text on the list page of this theme, but found that it wasn't extracted into a partial - so this PR does that.