### PR TITLE
Fix title when subtitle is empty

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,8 +8,10 @@
 
 {{ partial "favicon.html" . }}
 
-{{ if .IsHome }}
+{{ if and (.IsHome) (.Site.Params.subTitle) }}
 <title>{{ .Site.Title }} - {{ .Site.Params.subTitle }}</title>
+{{ else if .IsHome }}
+<title>{{ .Site.Title }}</title>
 {{ else }}
 <title>{{ .Title }} - {{ .Site.Title }}</title>
 {{ end }}


### PR DESCRIPTION
Remove the hyphen when the subtitle is empty.