### PR TITLE
Fix tag url when base url is /

### DIFF
--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -7,7 +7,7 @@
 <span>
     {{ if .Params.tags }}
     {{ range .Params.tags }}
-    <a href="{{ $.Site.BaseURL }}/tags/{{ . | urlize }}/">{{ . }}</a>
+    <a href="/tags/{{ . | urlize }}/">{{ . }}</a>
     {{ end }}
     {{ else }}
     <span>{{ i18n "postMetaNoTag" }}</span>


### PR DESCRIPTION
Tag url is broken when baseURL is "/". It can be fixed using relative url.