### PR TITLE
Fix html lang attribute

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -7,9 +7,8 @@ enableRobotsTXT = true
 disableKinds = ["taxonomyTerm"]
 
 ## Change this two to switch between different language
-## Now support: en, zh-hans, zh-hant, ja, nl
-defaultContentLanguage = "en"
-languageCode = "en"
+languageCode = "en"  # For RSS, view https://www.rssboard.org/rss-language-codes
+defaultContentLanguage = "en"  # For HTML page, now support: en, zh-hans, zh-hant, ja, nl
 
 summaryLength = 100 # Custom cummary length, add <!--more--> in post file to custom split point
 paginate = 10

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Lang }}">
 {{ partial "head.html" . }}
 
 <body class="d-flex flex-column h-100">


### PR DESCRIPTION
The languageCode is used for RSS, please refer to https://gohugo.io/variables/site and https://www.rssboard.org/rss-language-codes