### PR TITLE
fuji.scss: let the user override the theme

### DIFF
--- a/assets/scss/fuji.scss
+++ b/assets/scss/fuji.scss
@@ -1,5 +1,3 @@
-@import '_custom';
-
 // var & global
 @import '_var';
 @import '_global';
@@ -28,3 +26,6 @@
 
 // lazy image placeholder
 @import '_image';
+
+// let the user override the theme
+@import '_custom';


### PR DESCRIPTION
This allows a `[SITEROOT]/assets/scss/_custom.scss` file to override the theme without using `!important` everywhere.