### PR TITLE
fuji.scss: let the user override both the variables and the CSS rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ Use the `[SITEROOT]/layouts/partials/comment-*.html` to cover `themes/fuji/layou
 
 > Hugo extended version needed.
 
-You can cover theme's internal SCSS variables with your own. Create `[SITEROOT]/assets/scss/_custom.scss` to cover variables in SCSS.
+You can override theme's internal SCSS variables with your own. Create `[SITEROOT]/assets/scss/_custom_var.scss` to cover variables in SCSS.
 
-Varibales available:
+Variables available:
 
 ```scss
 $body-font: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', 'Helvetica', 'Arial', 'PingFang SC',
@@ -247,6 +247,9 @@ $dark-color-divider: #4d5158; // Discord
 $dark-color-bg: #2f3136; // Discord
 $dark-color-codebg: #414449; // GitHub
 ```
+
+To override SCSS rules, create `[SITEROOT]/assets/scss/_custom_rules.scss`. This file will have priority over anything regarding CSS rules, but is useless for changing variables that are used elsewhere in the theme.
+
 
 ## ✏️ Issue und contributing
 

--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -1,1 +1,1 @@
-// wtb covered
+// This file was used for overriding variables. Please use _custom_var.scss instead.

--- a/assets/scss/_custom_rules.scss
+++ b/assets/scss/_custom_rules.scss
@@ -1,0 +1,1 @@
+// Override CSS rules with that file

--- a/assets/scss/_custom_var.scss
+++ b/assets/scss/_custom_var.scss
@@ -1,0 +1,2 @@
+// Override variables with that file
+@import '_custom'; // Keep that for back-compatibility. This shouldn't be used anymore.

--- a/assets/scss/fuji.scss
+++ b/assets/scss/fuji.scss
@@ -1,5 +1,6 @@
 // var & global
 @import '_var';
+@import '_custom_var';
 @import '_global';
 
 // primer
@@ -28,4 +29,4 @@
 @import '_image';
 
 // let the user override the theme
-@import '_custom';
+@import '_custom_rules';


### PR DESCRIPTION
This MR allows overriding both the SCSS variables and the SCSS rules with two different files, loaded at different stages.