### PR TITLE
Footer improvements

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -34,6 +34,9 @@ paginate = 10
   author = "DSRKafuU" # You can also set author in post front matter individually
   subTitle = "A minimal Hugo theme."
 
+  # Source URL of the website, will appear in the footer
+  sourceURL = "https://github.com/itsme/my_blog"
+
   # Use CloudFlare Workers to accelerate the Google Analytics
   # If you are using this please comment the googleAnalytics above
   # Check https://github.com/SukkaW/cloudflare-workers-async-google-analytics for more details
@@ -48,9 +51,15 @@ paginate = 10
   showWordCounter = true
   showReadTime = false
 
+  # License in the footer
+  showLicenseInFooter = false
+
   # License at the end of each post
   showLicense = true
   showToc = true
+
+  # Copyright
+  copyrightStartYear = "2020"
 
   # Open Graph & Twitter Card variables
   # You can also set description and images in post front matter individually

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,10 +1,18 @@
 <footer>
     <div class="container-lg clearfix">
         <div class="col-12 footer">
-            <span>&copy; {{ now.Format "2006" }} <a href="{{ .Site.BaseURL }}">{{ .Site.Params.author }}</a> |
-                {{ i18n "footerPoweredFront" }}<a href="https://github.com/amzrk2/hugo-theme-fuji/"
-                   target="_blank">Fuji-v2</a> & <a href="https://gohugo.io/"
-                   target="_blank">Hugo</a>{{ i18n "footerPoweredEnd" }}</span>
+            {{ if .Site.Params.showLicenseInFooter }}
+            <p>
+                {{ i18n "postCopyrightFront" }}<a rel="license" href="{{ .Site.Params.licenseLink }}" target="_blank">{{ .Site.Params.license }}</a>{{ i18n "postCopyrightEnd" }}
+            </p>
+            {{ end }}
+            <span>&copy; {{ with .Site.Params.copyrightStartYear }}{{ . }}-{{ end }}{{ now.Format "2006" }}
+                <a href="{{ .Site.BaseURL }}">{{ .Site.Params.author }}</a>
+                {{ with .Site.Params.sourceURL }} | <a href="{{ . }}">source code</a> {{ end }}
+                | {{ i18n "footerPoweredFront" }}<a href="https://github.com/amzrk2/hugo-theme-fuji/"
+                   target="_blank">Fuji-v2</a> &amp; <a href="https://gohugo.io/"
+                                                    target="_blank">Hugo</a>{{ i18n "footerPoweredEnd" }}
+            </span>
         </div>
     </div>
 </footer>


### PR DESCRIPTION
Add multiple new options:
  - `sourceURL`: to provide a link to the website source code
  - `showLicenseInFooter`: to display the license in the footer
  - `copyrightStartYear`: to display the copyright with a range of years