### PR TITLE
remove `relURL` from `render-image` markup

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,1 +1,1 @@
-<img class="img-zoomable" src="{{ .Destination | relURL | safeURL }}" alt="{{ .Text }}" />
+<img class="img-zoomable" src="{{ .Destination | safeURL }}" alt="{{ .Text }}" />


### PR DESCRIPTION
this breaks relative markdown images, e.g.:

```
![example](images/examples.png)
```

doesn't work, because a `/` is appended, making it an absolute URL