### PR TITLE
Add support for Font Awesome

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -44,3 +44,5 @@
 {{ end }}
 {{ partial "analytic-gtag.html" . }}
 {{ partial "analytic-cfga.html" . }}
+<!-- Font Awesome -->
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/js/all.min.js"></script>

--- a/layouts/shortcodes/fa.html
+++ b/layouts/shortcodes/fa.html
@@ -1,0 +1,14 @@
+<!-- use default fontawesome class 'fas' or use a specified one like 'fab' for brands -->
+{{ $faStylePrefix := "fas" }}
+{{ if in (slice "fas" "far" "fal" "fad" "fab") (.Get 0) }}
+  {{ $faStylePrefix = (.Get 0) }}
+{{ end }}
+
+<i class="{{ $faStylePrefix }} {{ range $iconName := .Params }} fa-{{ $iconName }} {{ end }}">
+  <!-- Load font awesome only once per page, load it inside the <i> element
+    so it does not disturb the text flow (like removing spaces) -->
+  {{ if not (.Page.Scratch.Get "fontawesomeLoaded") }}
+    {{ .Page.Scratch.Set "fontawesomeLoaded" true }}
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css" rel="stylesheet">
+  {{ end }}
+</i>


### PR DESCRIPTION
# [Font Awesome](https://fontawesome.com/)

>Get vector icons and social logos on your website with Font Awesome, the web's most popular icon set and toolkit.

## Add global support for Font Awesome

Adding script to *head.html* makes Font Awesome globally available.

### [Usage](https://fontawesome.com/how-to-use/on-the-web/referencing-icons/basic-use)

Example:

  ```html
<i class="fas fa-camera"></i>
  ```

## Add short code support for Font Awesome

Create *fa.html* to add support for Font Awesome shortcodes in markdown.

>via: [Font Awesome in Hugo](https://matze.rocks/posts/fontawesome_in_hugo/)

### [Usage](https://matze.rocks/posts/fontawesome_in_hugo/#4-usage)

Example:

  ```html
{{< fa bath >}}
  ```