### PR TITLE
Set height of ToC to 80% of the screen height

### DIFF
--- a/assets/scss/_fuji-style/_sidebar.scss
+++ b/assets/scss/_fuji-style/_sidebar.scss
@@ -81,7 +81,7 @@
     top: 1rem;
 
     #TableOfContents {
-      max-height: 32rem;
+      max-height: 80vh;
       overflow: auto;
       scrollbar-width: thin;
     }


### PR DESCRIPTION
I've faced an issue when Table of contents looks awkward on larger screens if a list of item is long enough.
Basically, ToC is only shown partly halfway through the page with a scroll.
I figured that having relative `max-height` does the trick. I've implemented it on my page.
See example here:
https://mitelman.engineering/blog/python-best-practice/automating-python-best-practices-for-a-new-project/