### PR TITLE
Rename TOC to Table of contents

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,5 +1,5 @@
 [sidebarToc]
-    other = "TOC"
+    other = "Table of contents"
 
 [sidebarPages]
     other = "Pages"


### PR DESCRIPTION
Renaming "TOC" to "Table of contents" just looks more natural and reader friendly.