### PR TITLE
Fix tags url in post-meta

### DIFF
--- a/layouts/partials/post-meta.html
+++ b/layouts/partials/post-meta.html
@@ -2,4 +2,4 @@
 {{ if ne .Date.YearDay .Lastmod.YearDay }}<span><i class="iconfont icon-sync-circle-sharp"></i>&nbsp;{{ dateFormat ( or $.Site.Params.dateFormat "2006-01-02" ) $.Page.Params.LastMod }}</span>{{ end }}
 {{ if .Site.Params.showWordCounter }}<span><i class="iconfont icon-file-tray-sharp"></i>&nbsp;{{ i18n "postMetaWordCount" .WordCount}}</span>{{ end }}
 {{ if .Site.Params.showReadTime }}<span><i class="iconfont icon-time-sharp"></i>&nbsp;{{ i18n "postMetaReadingTime" .ReadingTime }}</span>{{ end }}
-<span><i class="iconfont icon-pricetags-sharp"></i>&nbsp;{{ if .Params.tags }}{{ range .Params.tags }}<a href="{{ "/tags/" | relURL }}{{ . | urlize}}">{{ . }}</a>&nbsp;{{ end }}{{ else }}{{ i18n "postMetaNoTag" }}{{ end }}</span>
+<span><i class="iconfont icon-pricetags-sharp"></i>&nbsp;{{ if .Params.tags }}{{ range .Params.tags }}<a href="{{ "tags/" | relURL }}{{ . | urlize}}">{{ . }}</a>&nbsp;{{ end }}{{ else }}{{ i18n "postMetaNoTag" }}{{ end }}</span>


### PR DESCRIPTION
When using a base url like `domain/dir/`, the URL of the tags in post-meta will be `domain/tags/tag-name` instead of `domain/dir/tags/tag-name`. This PR fixes it by changing the URL in `layouts/partials/post-meta.html` from `{{ "/tags/" | relURL }}` to `{{ "tags/" | relURL }}`.