### PR TITLE
Mobile optimizations

### DIFF
--- a/assets/scss/_fuji-style/_content.scss
+++ b/assets/scss/_fuji-style/_content.scss
@@ -26,6 +26,7 @@
   span {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
   }
 
   span:not(:last-child) {

--- a/assets/scss/_fuji-style/_header.scss
+++ b/assets/scss/_fuji-style/_header.scss
@@ -13,7 +13,7 @@ header {
   .title-sub {
     margin: 0 0.1rem;
     display: block;
-    white-space: nowrap;
+    white-space: normal;
 
     &::-webkit-scrollbar {
       display: none; // WebKit

--- a/exampleSite/content/post/post-meta-test.md
+++ b/exampleSite/content/post/post-meta-test.md
@@ -1,0 +1,9 @@
++++
+title = "Post-Meta Test with Lots of Tags"
+date = "2016-12-21"
+description = "Because existing posts don't have enough tags"
+tags = ["tags", "css", "cascading stylesheets", "html", "hypertext markup language", "fuji theme tests", "test", "text", "excessive tags"]
+showToc = false
++++
+
+**The tags should wrap and not make a horizontal scroll bar appear.** Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. 


### PR DESCRIPTION
There are two elements potentially breaking the responsive design on smaller screens: subtitle and tags. Changing `white-space: nowrap;` to `white-space: normal;` allows the subtitle to wrap. And adding `flex-wrap: wrap;` to .post-meta span allows the meta elements, most notably tags, to wrap.
Here are _before_ and _after_ screenshots of the newly included post-meta-test.md.
<img alt="tags-without-wrap" title="before" src="https://user-images.githubusercontent.com/103692194/208793863-03c005eb-894a-4a03-a7a8-3ae10f8dbaed.png" width="50%"><img alt="tags-with-wrap" title="after" src="https://user-images.githubusercontent.com/103692194/208793867-a07df73a-33f1-4d7a-adec-3844510c14e8.png" width="50%">
