### PR TITLE
Add Custom Darkmode Brightness

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -101,6 +101,9 @@ lazyPlaceholderCol = "/assets/lazyload/dsrca_loading_480x540.svg"
 # Let images display in full brightness under dark mode
 # disableDarkImage = true
 
+# Specify image brightness in dark mode
+# darkImageLevel = "85%"
+
 [markup]
 [markup.goldmark]
 [markup.goldmark.renderer]

--- a/layouts/partials/styles.html
+++ b/layouts/partials/styles.html
@@ -1,13 +1,14 @@
 {{ if ne .Site.Params.disableDarkImage true }}
+{{ $darkImageLevel := default "60%" .Site.Params.darkImageLevel }}
 <style>
     @media (prefers-color-scheme: dark) {
         body[data-theme='auto'] img {
-            filter: brightness(60%);
+            filter: brightness({{ $darkImageLevel }});
         }
     }
 
     body[data-theme='dark'] img {
-        filter: brightness(60%);
+        filter: brightness({{ $darkImageLevel }});
     }
 </style>
 {{ end }}


### PR DESCRIPTION
## Change
Allows custom dark mode brightness other than 60% or 100%

If the variable `.Site.Params.darkImageLevel` is left blank it default to 60%.


## Testing
Locally on website