### PR TITLE
Switch art-template to use the non min script

### DIFF
--- a/layouts/partials/scripts-end.html
+++ b/layouts/partials/scripts-end.html
@@ -1,5 +1,5 @@
 {{ if eq .Section "search" }}
-<script defer src="https://cdn.jsdelivr.net/npm/art-template@4.13.2/lib/template-web.min.js" integrity="sha512-/8K8Hs4pVcqd/wI87fQEzHCeGZVYPo3vMbmf8GzT3nQec19dfHVnRwBZHvkkzjaQSO9vpilow841VfvE6b86Lw==" crossorigin="anonymous"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/art-template@4.13.2/lib/template-web.js" integrity="sha256-5giHTB6g18PZS8ficjELg/n/f6asTMCLp7I0xKrZ6xk=" crossorigin="anonymous"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/fuse.js@6.5.3/dist/fuse.min.js" integrity="sha512-W+QdO2uEYG8oKLFGKPGGwT43RQWOBzAcxSpPMRyR6zAC3DLjMPp6GxoPvasKfs1pbYYXd0ByDCOiBd7M554qbw==" crossorigin="anonymous"></script>
 {{ else if eq .Section "archives" }}
 {{ else }}


### PR DESCRIPTION
#107 

The search feature does not work (not sure when my guess ~4 weeks ago)
From some poking around the code I found it was the art-template not the search.

Switching to using the non min code fixed it.

Pulled the sha256 from https://www.jsdelivr.com/package/npm/art-template?tab=files&path=lib
